### PR TITLE
Update Datadog Dashboard

### DIFF
--- a/jumpstart/templates/index.html
+++ b/jumpstart/templates/index.html
@@ -33,7 +33,7 @@
                 <div class="col-md-10" style="align-content: left; overflow: hidden;" align="left">
                     <!-- DataDog -->
                     <!-- Old Dash Link - https://p.datadoghq.com/sb/44f16805b-cab847d58c -->
-                    <iframe class="datadog" id="datadog" scrolling="no" frameborder="0" src="https://p.datadoghq.com/sb/44f16805b-4c2038873e353ef6fbb5cd49d9d2b1ac?theme=light&tv_mode=true&from_ts=1632504844081&to_ts=1632508444081&live=true?"></iframe>
+                    <iframe class="datadog" id="datadog" scrolling="no" frameborder="0" src="https://p.datadoghq.com/sb/44f16805b-663b1289003f0814a46720ff0d9472fc?theme=light&tv_mode=true&live=true?"></iframe>
                     <!-- Announcements -->
                     <div class="announcements">
                         <div class="panel panel-primary" style="overflow: hidden;">


### PR DESCRIPTION
The Datadog dashboard type used in new status board is the wrong type of board that doesn't scale correctly in TV mode, this is a newly recreated board in the screenboard format to allow for jumpstart to look good.