### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ This project uses [Python](http://nodejs.org), [Flask](https://npmjs.com), SQL, 
 
 Jumpstart expects the following environment variables to be defined:
 ```
-FLASK_APP=jumpstart:App
+FLASK_APP=jumpstart:app
 JUMPSTART_API_KEYS=KEYS
 TZ=TIMEZONE
-SENTRY_DSN=LINK
+SENTRY_DSN=LINK (could also be "")
 ```
 ## Docker
 
@@ -32,7 +32,7 @@ SENTRY_DSN=LINK
 ```
 docker run \
     -e FLASK_RUN_HOST=0.0.0.0 \
-    -e FLASK_APP=jumpstart:App \
+    -e FLASK_APP=jumpstart:app \
     -e JUMPSTART_API_KEYS=KEYS \
     -e TZ=America/New_York \
     -e SENTRY_DSN=LINK \


### PR DESCRIPTION
It should `app` and not `App` in env. Also, SENTRY_DSN could just be empty in dev (i might be wrong).

## What

Corrects README.md. It should `app` and not `App` in env. Also, SENTRY_DSN could just be empty in dev (i might be wrong).

## Why

Dev won't work.

## Test Plan

tested locally

## Env Vars

lowercased `A` in FLASK_APP=jumpstart:App

## Checklist

- [ x ] Tested all changes locally
